### PR TITLE
Auto-publish GitHub Action Workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,31 @@
+# (c) Copyright 2021 Christian Saide
+# SPDX-License-Identifier: MIT
+
+name: publish
+
+on:
+  push:
+    tags: [ "v*" ]
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_TOOLCHAIN: stable
+  TOOLCHAIN_PROFILE: minimal
+
+jobs:
+  publish:
+    name: publish
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+      - name: Install toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: ${{ env.TOOLCHAIN_PROFILE }}
+          toolchain: ${{ env.RUST_TOOLCHAIN }}
+          override: true
+      - name: Cache
+        uses: Swatinem/rust-cache@v1
+      - name: Publish
+        run: make CARGO_API_KEY="${{secrets.CRATES_RS_TOKEN}}" publish-ci

--- a/Makefile
+++ b/Makefile
@@ -183,8 +183,12 @@ package:
 	@cargo package --allow-dirty
 
 publish:
-	@bash ./dist/bin/print.sh "Packaging"
+	@bash ./dist/bin/print.sh "Publishing"
 	@cargo publish
+
+publish-ci:
+	@bash ./dist/bin/print.sh "Publishing"
+	@cargo --token $(CARGO_API_KEY) publish
 
 ###
 # Cleanup


### PR DESCRIPTION
The new action will eventually run `make CARGO_API_KEY={secret} publish-ci` which will in turn call cargo publish. This is keyed to only run on `v*` tag pushes.